### PR TITLE
Switch npm Dependabot updates to Tuesday

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,14 +6,16 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
       # @typescript-eslnt publishes new updates every Monday:
       # https://typescript-eslint.io/maintenance/releases#latest
       # Since we use multiple packages that need to be kept in sync with each other,
       # check for updates on Tuesday instead to avoid mismatched versions.
       # Remove after https://github.com/dependabot/dependabot-core/issues/1296 is implemented.
+      day: "tuesday"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      # Parity with npm.
       day: "tuesday"


### PR DESCRIPTION
I wasn't paying attention in #207 and only updated the GitHub Actions ecosystem, not the npm one which we actually care about 😅.