### PR TITLE
Group typescript-eslint updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,16 +6,12 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      # @typescript-eslnt publishes new updates every Monday:
-      # https://typescript-eslint.io/maintenance/releases#latest
-      # Since we use multiple packages that need to be kept in sync with each other,
-      # check for updates on Tuesday instead to avoid mismatched versions.
-      # Remove after https://github.com/dependabot/dependabot-core/issues/1296 is implemented.
-      day: "tuesday"
+    groups:
+      typescript-eslint:
+        patterns:
+        - "@typescript-eslint/*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
-      # Parity with npm.
-      day: "tuesday"


### PR DESCRIPTION
Now that Dependabot grouped updates are in beta, we can try this out.
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups