### PR TITLE
Remove obsolete TSESlint Dependabot rule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    groups:
-      typescript-eslint:
-        patterns:
-        - "@typescript-eslint/*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
This is no longer needed now that we're on the singular `typescript-eslint` package.